### PR TITLE
CI fixes

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,0 @@
-build_root_image:
-    name: ubi-minimal
-    namespace: ocp
-    tag: "8"

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ SHELL := /usr/bin/env bash
 
 IMAGE_REGISTRY ?= quay.io
 IMAGE_REPOSITORY ?= app-sre
-REGISTRY_USER ?=
-REGISTRY_TOKEN ?=
+QUAY_USER ?=
+QUAY_TOKEN ?=
 CONTAINER_ENGINE_CONFIG_DIR = .docker
 
 # Accommodate docker or podman

--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ This is to avoid the "disappearing digest" problem, facilitating by-digest pulls
 
 To test the app-sre pipeline:
 - Create personal repositories and override variables as described [above](#local-buildtest).
-- Obtain credentials from your personal repository and set the `REGISTRY_USER` and `REGISTRY_TOKEN` variables.
+- Obtain credentials from your personal repository and set the `QUAY_USER` and `QUAY_TOKEN` variables.
 - Run `make build-push`.


### PR DESCRIPTION
For prow, remove the in-repo root image config, as it is not being used (see https://github.com/openshift/release/pull/18599/files#r632773117)

For appsre, #1 introduced the wrong-named variables for quay login. Fix.