### PR TITLE
Add audit filter for write-request body logging

### DIFF
--- a/audit-filter/Makefile
+++ b/audit-filter/Makefile
@@ -1,0 +1,21 @@
+GOENV=CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on
+GOFLAGS=-ldflags='-extldflags=-static' -trimpath
+
+build: audit-log-exporter
+
+audit-log-exporter: *.go pkg/*/*.go vendor
+	$(GOENV) go build $(GOFLAGS) -o $@
+
+vendor: go.sum
+	$(GOENV) go mod vendor
+
+go.sum: go.mod
+	$(GOENV) go mod tidy
+	touch go.mod go.sum
+
+clean:
+	rm -f audit-log-exporter go.sum
+
+distclean:
+	git clean -ffdx
+

--- a/audit-filter/README.md
+++ b/audit-filter/README.md
@@ -1,0 +1,93 @@
+# audit-log-exporter
+
+Enables policy-driven event filtering and deduplication of OpenShift audit logs for OSD
+
+## Enabling in stage
+
+Forwarding audit logs to `openshift_managed_audit_stage` can be enabled by adding a policy file to the `osd-monitored-logs-local` configmap
+
+```bash
+oc set data cm/osd-monitored-logs-local --from-file=policy.yaml
+```
+
+An example [policy file](policy.yaml) is included in the repo
+
+The [startup script](../containers/forwarder/run.sh) in the universal forwarder image polls this file periodically for changes and enables or disables the input accordingly
+
+## Policy filtering
+
+The policy file uses the [Kubernetes audit policy](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/) format, extended slightly to allow wildcard suffixes for namespaces and user groups
+
+Rules are checked in order, and checking stops after the first matching rule. A `level` of `None` drops the request
+
+The example policy file included in the repo was generated from 4.7 and 4.8 audit log analysis
+
+## Default filtering
+
+Events for which __no policy rules__ match are filtered by the following conditions:
+
+* User events (ie. non-system and non-serviceaccount) are __forwarded__
+* Read-only system events (`get`/`list`/`watch` etc) are __dropped__
+* Control plane leader lease locks and renewals are __dropped__
+* `openshift-*` service account write events that occur within the same namespace are __dropped__
+* Requests that had a response code of `409`, `422` or `404` are __dropped__
+* All other events are __forwarded__
+
+## Deduplication
+
+The process by which `update` events that include the full object in the `requestBody` are deduplicated is:
+
+1. The `metadata.resourceVersion` and `metadata.generation` fields are removed (resourceVersion remains present at `objectRef.resourceVersion`)
+  * A number of [status and data fields](main.go#L38) are also removed, if present, to work around issues with certain resources
+2. The event is then converted to a `patch` request by generating a three-way JSON patch based on the previous cached `update` request, if one exists
+3. The event is discarded if a patch was generated but its body is empty
+
+Events converted from `update` to `patch` (but _not_ discarded) are annotated indicating the conversion. Metrics for discarded events are recorded in `events_processed_total{decision="drop",reason="no-op write"}`
+
+Because deduplication depends on the presence of the `requestBody`, it will only work when `WriteRequestBody` or `AllRequestBody` audit profiles are used, and will not work for resources that are only audited at the `Metadata` level (such as secrets)
+
+Deduplication can be disabled with `--dedupe=false`
+
+## Testing locally
+
+Fetch the audit logs from a master node with `WriteRequestBody` logging enabled:
+
+```bash
+POD=$(oc get pod  -n openshift-kube-apiserver -l apiserver=true -o name | head -n 1)
+oc exec -n openshift-kube-apiserver $POD -- bash -c 'cat /var/log/kube-apiserver/audit*.log | gzip -f -9' | gzip -d > audit.log
+```
+
+Basic usage:
+```bash
+./audit-log-exporter --input audit.log --policy policy.yaml > filtered.log
+```
+
+By default `audit-log-exporter` will try to follow input files until they are rotated, use the `--follow=false` flag to instead exit at EOF
+
+Metrics can be written to standard error at exit with `--print-metrics`, intended for testing against large audit files:
+
+```bash
+./audit-log-exporter --input audit.log --policy policy.yaml --follow=false --print-metrics >/dev/null
+[...]
+splunkforwarder_audit_filter_events_processed_total{decision="drop",reason="leader lease"} 33833.0
+splunkforwarder_audit_filter_events_processed_total{decision="drop",reason="no-op write"} 29555.0
+splunkforwarder_audit_filter_events_processed_total{decision="drop",reason="policy rule #1"} 9365.0
+splunkforwarder_audit_filter_events_processed_total{decision="drop",reason="policy rule #2"} 77110.0
+splunkforwarder_audit_filter_events_processed_total{decision="drop",reason="policy rule #5"} 183.0
+splunkforwarder_audit_filter_events_processed_total{decision="drop",reason="response code 409"} 1391.0
+splunkforwarder_audit_filter_events_processed_total{decision="drop",reason="response code 422"} 23.0
+splunkforwarder_audit_filter_events_processed_total{decision="forward",reason="policy rule #10"} 381.0
+splunkforwarder_audit_filter_events_processed_total{decision="forward",reason="policy rule #3"} 180.0
+splunkforwarder_audit_filter_events_processed_total{decision="forward",reason="policy rule #4"} 512.0
+```
+
+To show only the events that would normally be dropped, use `--invert`
+
+## TODO
+
+* Unit tests
+* Better policy
+* Move `policy.yaml` and `inputs.conf` into `splunk-forwarder-operator`
+* Configurable deduplication (eg, dedupe or merge event when CSVs are copied installed to all namespaces)
+* Configurable general field removal/anonymization
+* Second-level dedupe on heavy-forwarders

--- a/audit-filter/go.mod
+++ b/audit-filter/go.mod
@@ -1,0 +1,16 @@
+module github.com/openshift/splunk-forwarder-images/audit-filter
+
+go 1.13
+
+require (
+	github.com/fsnotify/fsnotify v1.4.9
+	github.com/hashicorp/golang-lru v0.5.4
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/common v0.10.0
+	github.com/spf13/pflag v1.0.5
+	golang.org/x/sys v0.0.0-20210426230700-d19ff857e887 // indirect
+	k8s.io/apimachinery v0.21.0
+	k8s.io/apiserver v0.21.0
+)

--- a/audit-filter/main.go
+++ b/audit-filter/main.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"container/heap"
+	"log"
+	"os"
+	"runtime"
+	"sync"
+
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apiserver/pkg/apis/audit"
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
+	auditpkg "k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/audit/event"
+
+	. "github.com/openshift/splunk-forwarder-images/audit-filter/pkg/event"
+	. "github.com/openshift/splunk-forwarder-images/audit-filter/pkg/filter"
+	"github.com/openshift/splunk-forwarder-images/audit-filter/pkg/metrics"
+	. "github.com/openshift/splunk-forwarder-images/audit-filter/pkg/reader"
+)
+
+var workers int
+var filter bool
+var follow bool
+var dedupe bool
+var invert bool
+var printmetrics bool
+var ignoreFields [][]string
+
+func main() {
+
+	inputfiles := []string{
+		"/host/var/log/kube-apiserver/audit.log",
+		"/host/var/log/openshift-apiserver/audit.log",
+		"/host/var/log/oauth-apiserver/audit.log",
+	}
+
+	policyfile := "/opt/splunkforwarder/etc/apps/osd_monitored_logs/local/policy.yaml"
+
+	// fields to ignore when deduplicating update requests
+	// TODO: make configurable, allow for anonymizing fields without dedupe
+	ignoreFields = [][]string{
+		// strictly required for dedupe to work
+		[]string{"metadata", "resourceVersion"},
+		[]string{"metadata", "generation"},
+		// workarounds and space-saving space
+		[]string{"metadata", "annotations", "kubectl.kubernetes.io/last-applied-configuration"},
+		[]string{"status", "relatedObjects"}, // cluster-operators reorder this slice on every update
+		[]string{"status", "conditions"},
+		[]string{"status", "lastSyncTimestamp"}, // from credentialsrequests
+		[]string{"status", "components"}, // olm reorders this slice on every update
+		[]string{"spec", "icon"},
+		[]string{"data", "ca.crt"},
+		[]string{"data", "ca-bundle.crt"},
+		[]string{"data", "service-ca.crt"},
+	}
+
+	dedupe = true
+	follow = true
+	invert = false
+	printmetrics = false
+	workers = 1 + runtime.NumCPU()
+
+	pflag.StringSliceVar(&inputfiles, "input", inputfiles, "audit log file(s) to monitor (can be repeated)")
+	pflag.StringVar(&policyfile, "policy", policyfile, "path to filter policy file")
+	pflag.BoolVar(&follow, "follow", follow, "follow and reopen files when rotated (tail -F)")
+	pflag.BoolVar(&dedupe, "dedupe", dedupe, "deduplicate repeated update requests")
+	pflag.BoolVar(&invert, "invert", invert, "only output dropped events (for testing)")
+	pflag.IntVar(&workers, "workers", workers, "number of decode workers")
+	pflag.BoolVar(&printmetrics, "print-metrics", printmetrics, "print metrics to stderr at exit")
+
+	pflag.Parse()
+
+	policy := LoadPolicy(policyfile, follow)
+
+	lines := ReadFiles(follow, inputfiles...)
+	decoded := make(chan Event)
+	filtered := make(chan audit.Event)
+
+	go Decode(lines, decoded)
+	go Filter(decoded, policy, filtered)
+	Encode(filtered)
+
+	if printmetrics {
+		metrics.Print()
+	}
+
+}
+
+// worker group for decoding json input
+func Decode(in <-chan Line, out chan Event) {
+	defer close(out)
+	gvk := (&auditv1.Event{}).TypeMeta.GroupVersionKind()
+	wg := sync.WaitGroup{}
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			codec := auditpkg.Codecs.LegacyCodec()
+			for line := range in {
+				ev := &audit.Event{}
+				_, _, err := codec.Decode(line.Data, &gvk, ev)
+				if err != nil {
+					metrics.RecordError()
+					log.Println("decode failed:", err)
+				}
+				obj := &unstructured.Unstructured{}
+				if dedupe == true && ev.Verb == "update" && ev.RequestObject != nil {
+					if err := obj.UnmarshalJSON(ev.RequestObject.Raw); err == nil {
+						for i := range ignoreFields {
+							unstructured.RemoveNestedField(obj.Object, ignoreFields[i]...)
+						}
+						ev.RequestObject.Raw = nil
+					}
+				}
+				attr, err := event.NewAttributes(ev)
+				if err != nil {
+					metrics.RecordError()
+					log.Println("attributes error:", err)
+				}
+				out <- Event{line.Index, *ev, attr, obj, metrics.ResourceLabels(ev), metrics.SubjectLabels(ev)}
+				metrics.RecordParsed()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// reorders and filters decoded events
+func Filter(in chan Event, policy *audit.Policy, out chan audit.Event) {
+	defer close(out)
+	q := make(EventQueue, 0)
+	heap.Init(&q)
+	index := uint64(1)
+	for event := range in {
+		for event.Index > index {
+			q.Add(event)
+			event = (<-in)
+		}
+		for event.Index == index {
+			if FilterEvent(&event, policy, dedupe) != invert {
+				out <- event.Event
+			}
+			index += 1
+			if len(q) > 0 {
+				if event = q.Next(); event.Index != index {
+					q.Add(event)
+					break
+				}
+			}
+		}
+	}
+}
+
+// encodes filtered events
+func Encode(in chan audit.Event) {
+	codec := auditpkg.Codecs.LegacyCodec(auditv1.SchemeGroupVersion)
+	for event := range in {
+		codec.Encode(&event, os.Stdout)
+	}
+}

--- a/audit-filter/pkg/event/event.go
+++ b/audit-filter/pkg/event/event.go
@@ -1,0 +1,66 @@
+package event
+
+import (
+	"container/heap"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+type Event struct {
+	Index uint64
+	audit.Event
+	Attributes     authorizer.Attributes
+	Object         *unstructured.Unstructured
+	ResourceLabels prometheus.Labels
+	SubjectLabels  prometheus.Labels
+}
+
+// returns the json-serialised requestObject
+func (e *Event) RequestBody() []byte {
+	if e.RequestObject != nil {
+		if e.Object != nil && e.RequestObject.Raw == nil {
+			e.RequestObject.Raw, _ = e.Object.MarshalJSON()
+		}
+		return e.RequestObject.Raw
+	}
+	return nil
+}
+
+// EventQueue holds Events and implements heap.Interface
+type EventQueue []*Event
+
+func (eq EventQueue) Len() int {
+	return len(eq)
+}
+
+func (eq EventQueue) Less(i, j int) bool {
+	return eq[i].Index < eq[j].Index
+}
+
+func (eq EventQueue) Swap(i, j int) {
+	eq[i], eq[j] = eq[j], eq[i]
+}
+
+func (eq *EventQueue) Push(x interface{}) {
+	*eq = append(*eq, x.(*Event))
+}
+
+func (eq *EventQueue) Pop() interface{} {
+	old := *eq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	*eq = old[0 : n-1]
+	return item
+}
+
+func (eq *EventQueue) Add(e Event) {
+	heap.Push(eq, &e)
+}
+
+func (eq *EventQueue) Next() Event {
+	return *heap.Pop(eq).(*Event)
+}

--- a/audit-filter/pkg/filter/filter.go
+++ b/audit-filter/pkg/filter/filter.go
@@ -1,0 +1,228 @@
+package filter
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	_ "unsafe"
+
+	"github.com/hashicorp/golang-lru"
+	jsonp "k8s.io/apimachinery/pkg/util/jsonmergepatch"
+	"k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/audit/policy"
+	authz "k8s.io/apiserver/pkg/authorization/authorizer"
+
+	. "github.com/openshift/splunk-forwarder-images/audit-filter/pkg/event"
+	. "github.com/openshift/splunk-forwarder-images/audit-filter/pkg/metrics"
+	"github.com/openshift/splunk-forwarder-images/audit-filter/pkg/reader"
+)
+
+func FilterEvent(e *Event, p *audit.Policy, dedupe bool) bool {
+
+	reason := ""
+
+	// check the policy first
+	if rulenum := MatchesPolicy(e, p); rulenum > 0 {
+
+		// record the matching rule number for metrics
+		reason = fmt.Sprintf("policy rule #%d", rulenum)
+
+		// policy says drop
+		if e.Level == audit.LevelNone {
+			return RecordDrop(e, reason)
+		}
+
+	} else {
+
+		// rules for events that aren't covered by the policy
+
+		// always keep user events
+		if e.User.Username != "" && !(strings.HasPrefix(e.User.Username, "system:")) {
+			return RecordForward(e, "user event")
+		}
+
+		// drop read-only system events
+		if e.Attributes.IsReadOnly() {
+			return RecordDrop(e, "system read")
+		}
+
+		// drop leader locks
+		if _, exists := e.Object.GetAnnotations()["control-plane.alpha.kubernetes.io/leader"]; exists {
+			return RecordDrop(e, "leader lease")
+		}
+
+		// for metadata-level updates (that can't be deduped), drop authorized intra-namespace system activity
+		if e.RequestObject == nil && e.Verb == "update" && strings.Contains(e.User.Username, e.ObjectRef.Namespace) &&
+			e.ResponseStatus.Code == 200 {
+			return RecordDrop(e, "system update")
+		}
+
+		// downgrade RequestResponse level to Request (except for create)
+		if e.Verb != "create" && e.Level.GreaterOrEqual(audit.LevelRequestResponse) {
+			e.Level = audit.LevelRequest
+			e.ResponseObject = nil
+		}
+
+	}
+
+	// drop 404s and temporary errors
+	if e.ResponseStatus != nil &&
+		e.ResponseStatus.Code == 404 || // often operators trying to delete non-existent resources
+		e.ResponseStatus.Code == 409 || // update conflicts (resource version too old)
+		e.ResponseStatus.Code == 422 { // server busy
+		return RecordDrop(e, fmt.Sprintf("response code %d", e.ResponseStatus.Code))
+	}
+
+	// deduplicate patches and updates
+	if dedupe == true && (e.Verb == "update" || e.Verb == "patch") &&
+		e.RequestObject != nil && e.ResponseStatus.Code == 200 &&
+		(IsDuplicate(e) || IsEmptyPatch(e)) {
+		return RecordDrop(e, "no-op write")
+	}
+
+	return RecordForward(e, reason)
+
+}
+
+var filterPolicy *audit.Policy
+
+func LoadPolicy(path string, watch bool) *audit.Policy {
+	var err error
+	if filterPolicy == nil {
+		filterPolicy, err = policy.LoadPolicyFromFile(path)
+		if err != nil {
+			log.Println("couldn't load policy:", err.Error())
+			filterPolicy = DefaultPolicy()
+		}
+		if watch {
+			go reader.WatchPolicyPath(path, filterPolicy)
+		}
+	}
+	return filterPolicy
+}
+
+// default policy to use if no valid policy is provided
+func DefaultPolicy() *audit.Policy {
+	return &audit.Policy{
+		Rules: []audit.PolicyRule{
+			audit.PolicyRule{
+				Level: audit.LevelNone,
+				Resources: []audit.GroupResources{
+					audit.GroupResources{Group: "authentication.k8s.io", Resources: []string{"tokenreviews"}},
+					audit.GroupResources{Group: "authorization.k8s.io", Resources: []string{"subjectaccessreviews"}},
+					audit.GroupResources{Group: "coordination.k8s.io", Resources: []string{"leases"}},
+				},
+			},
+		},
+	}
+}
+
+// checks an event against a policy, returns the matching rule number or 0 or there was no match
+func MatchesPolicy(e *Event, p *audit.Policy) int {
+	for i, r := range p.Rules {
+		if MatchesRule(e, &r) {
+			if audit.Level(r.Level).Less(e.Level) {
+				e.Level = audit.Level(r.Level)
+				if e.Level.Less(audit.LevelRequestResponse) {
+					e.ResponseObject = nil
+				}
+				if r.Level.Less(audit.LevelRequest) {
+					e.RequestObject = nil
+				}
+			}
+			return i + 1
+		}
+	}
+	return 0
+}
+
+//go:linkname ruleMatches k8s.io/apiserver/pkg/audit/policy.ruleMatches
+func ruleMatches(*audit.PolicyRule, authz.Attributes) bool
+
+func matchesWildcard(needle string, haystacks ...string) *string {
+	for _, haystack := range haystacks {
+		if strings.HasSuffix(needle, "*") && strings.HasPrefix(haystack, needle[:len(needle)-2]) {
+			return &haystack
+		}
+	}
+	return nil
+}
+
+func MatchesRule(e *Event, r *audit.PolicyRule) bool {
+	for i, group := range r.UserGroups {
+		if match := matchesWildcard(group, e.User.Groups...); match != nil {
+			new := r.DeepCopy()
+			new.UserGroups[i] = *match
+			r = new
+			break
+		}
+	}
+	if e.ObjectRef != nil {
+		for i, namespace := range r.Namespaces {
+			if match := matchesWildcard(namespace, e.ObjectRef.Namespace); match != nil {
+				new := r.DeepCopy()
+				new.Namespaces[i] = *match
+				r = new
+				break
+			}
+		}
+	}
+	return ruleMatches(r, e.Attributes)
+}
+
+// reduces an update to a patch, returns true on success
+func ReduceToPatch(e *Event) bool {
+	if now, then, ok := GetPreviousRequest(e); ok {
+		patch, err := jsonp.CreateThreeWayJSONMergePatch(then, now, then)
+		if err != nil {
+			return false
+		}
+		e.Verb, e.RequestObject.Raw = "patch", patch
+		return true
+	}
+	return false
+}
+
+func IsEmptyPatch(e *Event) bool {
+	if e.Level.GreaterOrEqual(audit.LevelRequest) && (e.Verb == "patch" || e.Verb == "update") {
+		if e.RequestObject == nil || e.RequestBody() == nil {
+			return true
+		} else {
+			raw := string(e.RequestBody())
+			return raw == "{}" || raw == "null" || raw == ""
+		}
+	} else if e.Level.GreaterOrEqual(audit.LevelMetadata) {
+		return false
+	}
+	return true
+}
+
+func IsDuplicate(e *Event) bool {
+	return ReduceToPatch(e) && IsEmptyPatch(e)
+}
+
+var Cache *lru.Cache
+
+func GetPreviousRequest(e *Event) ([]byte, []byte, bool) {
+	if e.RequestObject == nil {
+		return nil, nil, false
+	}
+	now := e.RequestBody()
+	if Cache == nil {
+		var err error
+		Cache, err = lru.New(1000)
+		if err != nil {
+			log.Println("warning: can't init event cache: ", err)
+			return now, nil, false
+		}
+	}
+	SetCachedObjectsCount(Cache.Len())
+	key := strings.Split(e.RequestURI, "?")[0]
+	defer Cache.Add(key, now)
+	if val, ok := Cache.Get(key); ok {
+		if then, ok := val.([]byte); ok {
+			return now, then, ok
+		}
+	}
+	return now, nil, false
+}

--- a/audit-filter/pkg/metrics/metrics.go
+++ b/audit-filter/pkg/metrics/metrics.go
@@ -1,0 +1,175 @@
+package metrics
+
+import (
+	"log"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+	"strings"
+
+	. "github.com/openshift/splunk-forwarder-images/audit-filter/pkg/event"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/expfmt"
+	"k8s.io/apiserver/pkg/apis/audit"
+)
+
+const namespace string = "splunkforwarder"
+const subsystem string = "audit_filter"
+
+var (
+	registry *prometheus.Registry
+
+	parsedCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "events_total",
+			Help:      "count of events parsed",
+		})
+
+	forwardedResourceCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "events_forwarded_resource",
+			Help:      "count of accepted events by resource and verb",
+		}, []string{"verb", "resource"})
+
+	forwardedSubjectCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "events_forwarded_subject",
+			Help:      "count of accepted events by subject and verb",
+		}, []string{"verb", "subject"})
+
+	droppedResourceCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "events_dropped_resource",
+			Help:      "count of dropped events by resource and verb",
+		}, []string{"verb", "resource"})
+
+	droppedSubjectCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "events_dropped_subject",
+			Help:      "count of dropped events by subject kind, verb and reason",
+		}, []string{"verb", "subject"})
+
+	processedCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "events_processed_total",
+			Help:      "count of processed events",
+		}, []string{"decision", "reason"})
+
+	errorCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "errors_total",
+			Help:      "count of encoding or decoding errors",
+		})
+
+	cachedObjects = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "cached_objects",
+			Help:      "number of objects in cache",
+		})
+)
+
+func init() {
+
+	prometheus.MustRegister(parsedCounter, processedCounter,
+		forwardedResourceCounter, forwardedSubjectCounter,
+		droppedResourceCounter, droppedSubjectCounter,
+		errorCounter, cachedObjects)
+
+	http.Handle("/metrics", promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{
+		Registry: prometheus.DefaultRegisterer,
+	}))
+
+	go http.ListenAndServe(":9090", nil)
+
+}
+
+func Print() {
+	mfs, _ := prometheus.DefaultGatherer.Gather()
+	w := expfmt.NewEncoder(os.Stderr, expfmt.FmtOpenMetrics)
+	for _, mf := range mfs {
+		if err := w.Encode(mf); err != nil {
+			log.Println(err)
+		}
+	}
+}
+
+func SubjectLabels(e *audit.Event) prometheus.Labels {
+	s := "User"
+	if strings.HasPrefix(e.User.Username, "system:serviceaccount:") {
+		s = "ServiceAccount"
+	} else if strings.HasPrefix(e.User.Username, "system:node:") {
+		s = "Node"
+	} else if strings.HasPrefix(e.User.Username, "system:anonymous") {
+		s = "Anonymous"
+	} else if strings.HasPrefix(e.User.Username, "system:") {
+		s = "SystemUser"
+	}
+	return prometheus.Labels(map[string]string{
+		"verb":    e.Verb,
+		"subject": s,
+	})
+}
+
+func ResourceLabels(e *audit.Event) prometheus.Labels {
+	r := "" // non-resource request
+	if e.ObjectRef != nil {
+		r = e.ObjectRef.Resource
+		if e.ObjectRef.Subresource != "" {
+			r = r + "/" + e.ObjectRef.Subresource
+		}
+	}
+	return prometheus.Labels(map[string]string{
+		"verb":     e.Verb,
+		"resource": r,
+	})
+}
+
+func VerdictLabels(action, reason string) prometheus.Labels {
+	return prometheus.Labels(map[string]string{
+		"decision": action,
+		"reason":   reason,
+	})
+}
+
+func RecordDrop(e *Event, reason string) bool {
+	droppedResourceCounter.With(e.ResourceLabels).Inc()
+	droppedSubjectCounter.With(e.SubjectLabels).Inc()
+	processedCounter.With(VerdictLabels("drop", reason)).Inc()
+	return false
+}
+
+func RecordForward(e *Event, reason string) bool {
+	forwardedResourceCounter.With(e.ResourceLabels).Inc()
+	forwardedSubjectCounter.With(e.SubjectLabels).Inc()
+	processedCounter.With(VerdictLabels("forward", reason)).Inc()
+	return true
+}
+
+func RecordParsed() {
+	parsedCounter.Inc()
+}
+
+func RecordError() {
+	errorCounter.Inc()
+}
+
+func SetCachedObjectsCount(i int) {
+	cachedObjects.Set(float64(i))
+}

--- a/audit-filter/pkg/reader/reader.go
+++ b/audit-filter/pkg/reader/reader.go
@@ -1,0 +1,211 @@
+package reader
+
+// TODO: redo all of this garbage
+
+import (
+	"bufio"
+	"io"
+	"io/ioutil"
+	"log"
+
+	"os"
+	"path"
+	"sync"
+	"syscall"
+
+	"github.com/fsnotify/fsnotify"
+	"k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/audit/policy"
+)
+
+type Line struct {
+	Index uint64
+	Data []byte
+}
+
+type RotatingReader struct {
+	*io.PipeReader
+	Path string
+	file *os.File
+	*fsnotify.Watcher
+	inode uint64
+	sync.WaitGroup
+	rotated chan struct{}
+	updated chan struct{}
+	writer  *io.PipeWriter
+}
+
+func NewRotatingReader(follow bool, filepath string) *RotatingReader {
+	f := &RotatingReader{}
+	f.PipeReader, f.writer = io.Pipe()
+//	if follow {
+		f.monitorPath(follow, filepath)
+//	}
+	go func() {
+		defer func() {
+			f.writer.Close()
+//			close(f.Events)
+			<-f.updated
+			close(f.updated)
+		}()
+		for {
+		read_file:
+			for {
+				f.Wait()
+				reader := io.TeeReader(f.file, f.writer)
+				io.Copy(ioutil.Discard, reader)
+				if !follow {
+					return
+				}
+				select {
+				case <-f.rotated:
+					go io.Copy(ioutil.Discard, reader)
+					break read_file
+				case <-f.updated:
+					for {
+						n, err := io.Copy(ioutil.Discard, reader)
+						if n == 0 || err != nil {
+							break
+						}
+					}
+				}
+			}
+		}
+	}()
+	return f
+}
+
+func (r *RotatingReader) monitorPath(follow bool, filepath string) {
+	r.Path = filepath
+	fd, err := os.Open(filepath)
+	if err != nil {
+		r.WaitGroup.Add(1)
+	}
+	r.file = fd
+	r.Watcher, err = fsnotify.NewWatcher()
+	r.updated = make(chan struct{})
+	r.rotated = make(chan struct{})
+	r.Watcher.Add(filepath)
+	r.Watcher.Add(path.Dir(filepath))
+	go func() {
+		for {
+			<-r.Events
+			if r.file == nil {
+				r.file, err = os.Open(filepath)
+				if err != nil {
+					continue
+				}
+				r.inode = GetInode(r.file)
+				r.Done()
+			}
+			if !follow {
+				return
+			}
+			r.updated <- struct{}{}
+			if r.file != nil && r.hasRotated() {
+				r.file = nil
+				if !follow {
+					return
+				}
+				r.rotated <- struct{}{}
+				r.WaitGroup.Add(1)
+			}
+		}
+	}()
+}
+
+func (f *RotatingReader) hasRotated() bool {
+	if f.inode == 0 {
+		f.inode = GetInode(f.file)
+	}
+	return f.inode != GetInode(f.Path)
+}
+
+func GetInode(file interface{}) uint64 {
+	var fi os.FileInfo
+	var err error
+	switch file.(type) {
+	case *os.File:
+		fi, err = file.(*os.File).Stat()
+	default:
+		fi, err = os.Stat(file.(string))
+	}
+	if err != nil {
+		return 0
+	}
+	return fi.Sys().(*syscall.Stat_t).Ino
+}
+
+func WatchPolicyPath(filepath string, p *audit.Policy) {
+	var wd *fsnotify.Watcher
+	var err error
+	for {
+		wd, err = fsnotify.NewWatcher()
+		if err != nil {
+			log.Fatal(err)
+		}
+		wd.Add(filepath)
+		wd.Add(path.Dir(filepath))
+		wd.Add(path.Dir(path.Dir(filepath))) // for k8s
+		for {
+			select {
+			case ev := <-wd.Events:
+				if ev.Op&(fsnotify.Rename|fsnotify.Remove|fsnotify.Write|fsnotify.Create) == 0 {
+					continue
+				}
+				newPolicy, err := policy.LoadPolicyFromFile(filepath)
+				if err != nil {
+					continue
+				}
+				*p = *newPolicy
+				log.Println("policy has been reloaded")
+			case err := <-wd.Errors:
+				log.Println(err)
+			}
+			break
+		}
+	}
+}
+
+
+func ReadFiles(follow bool, paths ...string) <-chan Line {
+
+	var wg sync.WaitGroup
+	var m sync.Mutex
+	_index := uint64(0)
+	index := func() uint64 {
+		defer m.Unlock()
+		m.Lock()
+		_index += 1
+		return _index
+	}
+
+	output := make(chan Line)
+
+	mux := func(f *RotatingReader, output chan Line) {
+		defer wg.Done()
+		reader := bufio.NewReaderSize(f, 102400)
+		for {
+			line, err := reader.ReadBytes('\n')
+			if err != nil {
+				if !follow {
+					return
+				}
+				continue
+			}
+			output <- Line{index(), line[:]}
+		}
+	}
+
+	wg.Add(len(paths))
+	for _, path := range paths {
+		go mux(NewRotatingReader(follow, path), output)
+	}
+
+	go func() {
+		defer close(output)
+		wg.Wait()
+	}()
+
+	return output
+}

--- a/audit-filter/policy.yaml
+++ b/audit-filter/policy.yaml
@@ -1,0 +1,164 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+metadata:
+  name: SplunkForwarder
+rules:
+# 1. drop common non-resource read requests (~10k/day)
+- level: None
+  nonResourceURLs:
+  - /
+  - /api*
+  - /healthz*
+  - /livez*
+  - /openapi/v2*
+  - /readyz*
+  - /version
+  - /.well-known*
+  verbs:
+  - get
+  - head
+  - options
+# 2. drop leases, tokenreviews, subjectaccessreviews (~100k/day)
+- level: None
+  resources:
+  - group: coordination.k8s.io
+    resources: ['leases']
+  - group: authentication.k8s.io
+    resources: ['tokenreviews']
+  - group: oauth.openshift.io
+    resources: ['tokenreviews']
+  - group: authorization.k8s.io
+    resources:
+    - subjectaccessreviews
+    - selfsubjectaccessreviews
+# 3. reduce events with sensitive content to metadata
+- level: Metadata
+  resources:
+  - group: machineconfiguration.openshift.io
+    resources: ['machineconfigs']
+  - resources: ['serviceaccounts/token']
+  - group: oauth.openshift.io
+    resources: ['oauthclients']
+  - group: image.openshift.io
+    resources: ['imagestreams/secrets']
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+# 4. always forward system:admin activity
+- level: Request
+  users: ['system:admin']
+# 5&6. always forward backplane activity (except for cronjob sa's)
+- level: None
+  users:
+  - system:serviceaccount:openshift-backplane:osd-delete-backplane-serviceaccounts
+  - system:serviceaccount:openshift-backplane-srep:osd-delete-ownerrefs-serviceaccounts
+- level: RequestResponse
+  userGroups:
+  - system:serviceaccounts:openshift-backplane-*
+# 7. drop control plane reads (~100k/day)
+- level: None
+  users:
+  - system:apiserver
+  - system:kube-apiserver
+  - system:kube-scheduler
+  - system:kube-controller-manager
+  verbs:
+  - get
+  - head
+  - list
+  - watch
+# 8. drop node and openshift-internal sa reads (~1M/day)
+- level: None
+  userGroups:
+  - system:nodes
+  - system:serviceaccounts:kube-*
+  - system:serviceaccounts:openshift-*
+  verbs:
+  - get
+  - list
+  - watch
+# 9. drop sre-build-test activity (~2k/day, large)
+- level: None
+  namespaces: ['openshift-build-test-*']
+# 10. always forward resources we're interested in
+- level: Request
+  resources:
+  - resources:
+    - pods
+  - group: compliance.openshift.io
+    resources:
+    - compliancecheckresults
+  - group: secscan.quay.redhat.com
+    resources:
+    - imagemanifestvulns
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+# 11. drop noisy system status updates (~100k/day)
+- level: None
+  userGroups:
+  - system:nodes
+  - system:serviceaccounts
+  - system:masters
+  resources:
+  - resources: ['*/status']
+  - group: apps
+    resources: ['*/status']
+  - group: batch
+    resources: ['*/status']
+  - group: managed.openshift.io
+    resources: ['subjectpermissions/status']
+  - group: operators.coreos.com
+    resources: ['catalogsources/status']
+  - group: apiserver.openshift.io
+    resources: ['apirequestcounts/*', 'apirequestcounts']
+  - group: controlplane.operator.openshift.io
+    resources: ['podnetworkconnectivitychecks/status']
+  - group: velero.io
+    resources: ['backups','backupstoragelocations/status']
+  verbs: ['update','patch']
+# 12. drop olm no-op updates (~10k/day)
+- level: None
+  users: ['system:serviceaccount:openshift-operator-lifecycle-manager:olm-operator-serviceaccount']
+  resources:
+  - resources: ['namespaces']
+  - group: operators.coreos.com
+    resources: ['clusterserviceversions']
+    resourceNames: ['packageserver']
+  - group: rbac.authorization.k8s.io
+    resources: ['clusterroles']
+  verbs: ['update','patch']
+# 13. drop cmo no-op secret updates (~1k/day)
+- level: None
+  users: ['system:serviceaccount:openshift-monitoring:cluster-monitoring-operator']
+  resources:
+  - resources: ['secrets']
+  verbs: ['update']
+# 14. drop console no-op route updates (~1k/day)
+- level: None
+  users: ['system:serviceaccount:openshift-console-operator:console-operator']
+  resources:
+  - group: route.openshift.io
+    resources: ['routes']
+    resourceNames: ['console','downloads']
+  verbs: ['update']
+# 15. drop clusterrole rbac aggregation updates (~500/day, large)
+- level: None
+  users: ['system:serviceaccount:kube-system:clusterrole-aggregation-controller']
+  resources:
+  - group: rbac.authorization.k8s.io
+    resources: ['clusterroles']
+  verbs: ['update','patch']
+# 16. drop cvo no-op imagestream updates (1k/day)
+- level: None
+  users: ['system:serviceaccount:openshift-cluster-version:default']
+  resources:
+  - group: image.openshift.io
+    resources: ['imagestreams']
+  verbs: ['update']

--- a/containers/forwarder/Dockerfile
+++ b/containers/forwarder/Dockerfile
@@ -1,3 +1,8 @@
+FROM registry.ci.openshift.org/openshift/release:golang-1.13 AS builder
+COPY audit-filter /go/src/audit-filter
+WORKDIR /go/src/audit-filter
+RUN make build
+
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 ADD containers/forwarder/bin/run.sh /
@@ -15,13 +20,15 @@ RUN export VERSION=$(cat /.splunk-version) && export VERSION_HASH=$(cat /.splunk
     mkdir -p /opt/splunkforwarder/var/run/splunk/appserver/{i18n,modules/static/css} && \
     mkdir -p /opt/splunkforwarder/var/run/splunk/{upload,search_telemetry} && \
     mkdir -p /opt/splunkforwarder/var/spool/dirmoncache && \
-    mkdir -p /opt/splunkforwarder/etc/apps/osd_monitored_logs/{local,metadata} && \
+    mkdir -p /opt/splunkforwarder/etc/apps/osd_monitored_logs/{default,local,metadata} && \
     mkdir -p /opt/splunkforwarder/etc/apps/splunkauth/{default,local,metadata} && \
     chown -R splunk:splunk /opt/splunkforwarder && \
     chown -R splunk:splunk /run.sh && \
     chmod +x /run.sh && \
     sed -i 's/\.maxBackupIndex=5/\.maxBackupIndex=1/g' /opt/splunkforwarder/etc/log.cfg && \
     sed -i 's/\.maxFileSize=25000000/\.maxFileSize=250000/g' /opt/splunkforwarder/etc/log.cfg
+
+COPY --from=builder /go/src/audit-filter/audit-log-exporter /opt/splunkforwarder/etc/apps/osd_monitored_logs/bin/
 
 USER splunk
 CMD [ "/run.sh" ]

--- a/containers/forwarder/bin/run.sh
+++ b/containers/forwarder/bin/run.sh
@@ -2,27 +2,81 @@
 
 cd /opt/splunkforwarder
 
-SPLUNK_ARGS="--answer-yes --gen-and-print-passwd --nodaemon"
+SPLUNK_ARGS="--answer-yes"
+SPLUNK_APP=osd_monitored_logs
 
 if [[ ${SPLUNK_ACCEPT_LICENSE} == "yes" ]]; then
     SPLUNK_ARGS="${SPLUNK_ARGS} --accept-license"
 fi
 
+. bin/setSplunkEnv
+
+export SPLUNK_PASS=$(openssl rand -base64 32 | tr -dc [:alnum:]) APP_PATH=etc/apps/${SPLUNK_APP}
+
+printf "[user_info]\nUSERNAME=admin\nPASSWORD=%s\n" ${SPLUNK_PASS} > etc/system/local/user-seed.conf
+
+# temporary hack until sfo can set up these two files
+if [ -s ${APP_PATH}/local/inputs.conf ]; then
+    cat > ${APP_PATH}/default/inputs.conf <<-EOF
+[script://./bin/audit-log-exporter]
+disabled = true
+interval = 0
+source = kube-apiserver.log
+sourcetype = _json
+index = openshift_managed_audit_stage
+EOF
+    cat > ${APP_PATH}/default/props.conf <<-EOF
+[_json]
+TRUNCATE = 10000000
+INDEXED_EXTRACTIONS = json
+KV_MODE = none
+LINE_BREAKER = ([\r\n]+)
+NO_BINARY_CHECK = true
+DATETIME_CONFIG =
+TIMESTAMP_FIELDS = stageTimestamp
+TZ = GMT
+disabled = false
+EOF
+    egrep _meta ${APP_PATH}/local/inputs.conf | head -n 1 >> ${APP_PATH}/default/inputs.conf
+fi
+
 ./bin/splunk start ${SPLUNK_ARGS}
 
-# The above command still forks to the background even with --nodaemon so 
+LAST_INPUTS_CHECKSUM="$(cksum ${APP_PATH}/local/inputs.conf)"
+
+# The above command still forks to the background even with --nodaemon so
 # we do the tried and true while true sleep
-SPLINK_PID_FILE="/opt/splunkforwarder/var/run/splunk/splunkd.pid"
-while true; do
-    if [[ ! -f $SPLUNK_PID_FILE ]]; then
-        exit 1
+SPLUNK_PID_FILE="/opt/splunkforwarder/var/run/splunk/splunkd.pid"
+while test -s $SPLUNK_PID_FILE; do
+
+    sleep 5
+
+    ps -p $(tr -dc [0-9][:space:] <${SPLUNK_PID_FILE}) > /dev/null || exit 1
+
+    # Check for presence of an audit forwarding policy file
+    if [ -s ${APP_PATH}/local/policy.yaml ]; then
+        if grep -sq "disabled = true" ${APP_PATH}/default/inputs.conf; then
+            sed -i "s/disabled = true/disabled = false/" ${APP_PATH}/default/inputs.conf
+            splunk reload exec -auth "admin:${SPLUNK_PASS}" -app ${SPLUNK_APP}
+        fi
+    else
+        if grep -sq "disabled = false" ${APP_PATH}/default/inputs.conf; then
+            sed -i "s/disabled = false/disabled = true/" ${APP_PATH}/default/inputs.conf
+            splunk reload exec -auth "admin:${SPLUNK_PASS}" -app ${SPLUNK_APP}
+        fi
     fi
 
-    SPLUNK_PID=$(head -1 ${SPLUNK_PID_FILE})
-    ps -p $SPLUNK_PID > /dev/null || exit 1
+    INPUTS_CHECKSUM="$(cksum ${APP_PATH}/local/inputs.conf)"
 
-    # Clean up old metric logs
-    ls /opt/splunkforwarder/var/log/splunk/metrics.log.* && rm -f ls /opt/splunkforwarder/var/log/splunk/metrics.log.*
+    # If the contents of the inputs.conf file has changed, reload monitor and exec inputs
+    if [ "$INPUTS_CHECKSUM" != "$LAST_INPUTS_CHECKSUM" ]; then
+        splunk reload monitor -auth "admin:${SPLUNK_PASS}" -app ${SPLUNK_APP}
+        splunk reload exec -auth "admin:${SPLUNK_PASS}" -app ${SPLUNK_APP}
+    fi
 
-    sleep 5;
+    LAST_INPUTS_CHECKSUM="$INPUTS_CHECKSUM"
+
+    # Clean up old logs
+    find var/log -type f -iname '*.log.*' -exec rm {} +
+
 done


### PR DESCRIPTION
This is for getting the audit-log-exporter binary into the splunk-forwarder image