### PR TITLE
Make forwarding of splunk-internal logs configurable

### DIFF
--- a/containers/forwarder/Dockerfile
+++ b/containers/forwarder/Dockerfile
@@ -23,5 +23,7 @@ RUN export VERSION=$(cat /.splunk-version) && export VERSION_HASH=$(cat /.splunk
     sed -i 's/\.maxBackupIndex=5/\.maxBackupIndex=1/g' /opt/splunkforwarder/etc/log.cfg && \
     sed -i 's/\.maxFileSize=25000000/\.maxFileSize=250000/g' /opt/splunkforwarder/etc/log.cfg
 
+COPY containers/forwarder/etc/defaults-disabled-inputs.conf /opt/splunkforwarder/etc/system/local/
+
 USER splunk
 CMD [ "/run.sh" ]

--- a/containers/forwarder/bin/run.sh
+++ b/containers/forwarder/bin/run.sh
@@ -8,9 +8,13 @@ if [[ ${SPLUNK_ACCEPT_LICENSE} == "yes" ]]; then
     SPLUNK_ARGS="${SPLUNK_ARGS} --accept-license"
 fi
 
+if [[ "${SHIP_INTERNAL_LOGS}" == "false" ]]; then
+    cat etc/system/local/defaults-disabled-inputs.conf >> etc/system/local/inputs.conf
+fi
+
 ./bin/splunk start ${SPLUNK_ARGS}
 
-# The above command still forks to the background even with --nodaemon so 
+# The above command still forks to the background even with --nodaemon so
 # we do the tried and true while true sleep
 SPLINK_PID_FILE="/opt/splunkforwarder/var/run/splunk/splunkd.pid"
 while true; do

--- a/containers/forwarder/etc/defaults-disabled-inputs.conf
+++ b/containers/forwarder/etc/defaults-disabled-inputs.conf
@@ -1,0 +1,26 @@
+[monitor://$SPLUNK_HOME/var/log/splunk]
+disabled = true
+
+[monitor://$SPLUNK_HOME/var/log/splunk/license_usage_summary.log]
+disabled = true
+
+[monitor://$SPLUNK_HOME/var/log/splunk/metrics.log]
+disabled = true
+
+[monitor://$SPLUNK_HOME/var/log/splunk/splunk_instrumentation_cloud.log*]
+disabled = true
+
+[monitor://$SPLUNK_HOME/var/log/splunk/splunkd.log]
+disabled = true
+
+[monitor://$SPLUNK_HOME/var/log/watchdog/watchdog.log*]
+disabled = true
+
+[monitor://$SPLUNK_HOME/var/run/splunk/search_telemetry/*search_telemetry.json]
+disabled = true
+
+[monitor://$SPLUNK_HOME/var/spool/splunk/...stash_new]
+disabled = true
+
+[monitor://$SPLUNK_HOME/var/log/introspection]
+disabled = true

--- a/containers/heavy_forwarder/Dockerfile
+++ b/containers/heavy_forwarder/Dockerfile
@@ -25,5 +25,7 @@ RUN export VERSION=$(cat /.splunk-version) && export VERSION_HASH=$(cat /.splunk
     sed -i 's/\.maxBackupIndex=5/\.maxBackupIndex=1/g' /opt/splunk/etc/log.cfg && \
     sed -i 's/\.maxFileSize=25000000/\.maxFileSize=250000/g' /opt/splunk/etc/log.cfg
 
+COPY containers/heavy_forwarder/etc/defaults-disabled-inputs.conf /opt/splunk/etc/system/local/
+
 USER splunk
 CMD [ "/run.sh" ]

--- a/containers/heavy_forwarder/bin/run.sh
+++ b/containers/heavy_forwarder/bin/run.sh
@@ -8,6 +8,10 @@ if [[ ${SPLUNK_ACCEPT_LICENSE} == "yes" ]]; then
     SPLUNK_ARGS="${SPLUNK_ARGS} --accept-license"
 fi
 
+if [[ "${SHIP_INTERNAL_LOGS}" == "false" ]]; then
+    cat etc/system/local/defaults-disabled-inputs.conf >> etc/system/local/inputs.conf
+fi
+
 # Switch to forwarder license
 ./bin/splunk edit licenser-groups Forwarder -is_active 1 ${SPLUNK_ARGS}
 

--- a/containers/heavy_forwarder/etc/defaults-disabled-inputs.conf
+++ b/containers/heavy_forwarder/etc/defaults-disabled-inputs.conf
@@ -1,0 +1,26 @@
+[monitor://$SPLUNK_HOME/var/log/splunk]
+disabled = true
+
+[monitor://$SPLUNK_HOME/var/log/splunk/license_usage_summary.log]
+disabled = true
+
+[monitor://$SPLUNK_HOME/var/log/splunk/metrics.log]
+disabled = true
+
+[monitor://$SPLUNK_HOME/var/log/splunk/splunk_instrumentation_cloud.log*]
+disabled = true
+
+[monitor://$SPLUNK_HOME/var/log/splunk/splunkd.log]
+disabled = true
+
+[monitor://$SPLUNK_HOME/var/log/watchdog/watchdog.log*]
+disabled = true
+
+[monitor://$SPLUNK_HOME/var/run/splunk/search_telemetry/*search_telemetry.json]
+disabled = true
+
+[monitor://$SPLUNK_HOME/var/spool/splunk/...stash_new]
+disabled = true
+
+[monitor://$SPLUNK_HOME/var/log/introspection]
+disabled = true


### PR DESCRIPTION
The majority of data ingested is currently from [splunk-internal logs
](https://osdsecuritylogs.splunkcloud.com/en-GB/app/splunk_instance_monitoring/search?sid=1621319324.320487)

This change disables all forwarding of splunk-internal logs except those needed for version tracking. It has been tested on running pods in production to alleviate pressure on indexers, last month and again last week