### PR TITLE
Use CGO_ENABLED=1

### DIFF
--- a/containers/forwarder/Dockerfile
+++ b/containers/forwarder/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/app-sre/golangci-lint:latest AS builder
 ADD . /go/src/github.com/openshift/splunk-forwarder-images
 WORKDIR /go/src/github.com/openshift/splunk-forwarder-images
-RUN env CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags=-static -w -s" -o runner ./
+RUN env CGO_ENABLED=1 GOOS=linux go build -ldflags "-extldflags=-static -w -s" -o runner ./
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-17665

Building with `CGO_ENABLED=1` is required to be FIPS compliant