### PR TITLE
updated and specify base tag to patch CVE's for FedRAMP CONMON

### DIFF
--- a/containers/forwarder/Dockerfile
+++ b/containers/forwarder/Dockerfile
@@ -3,7 +3,7 @@ ADD . /go/src/github.com/openshift/splunk-forwarder-images
 WORKDIR /go/src/github.com/openshift/splunk-forwarder-images
 RUN env CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags=-static -w -s" -o runner ./
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
 
 COPY --from=builder /go/src/github.com/openshift/splunk-forwarder-images/runner /
 ADD containers/forwarder/bin/systemctl_wrapper.sh /bin/systemctl

--- a/containers/heavy_forwarder/Dockerfile
+++ b/containers/heavy_forwarder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
 
 ADD containers/heavy_forwarder/bin/run.sh /
 ADD .splunk-version /


### PR DESCRIPTION
* Updates base image to latest to patch CVE's
* Defines a tag vs using latest as there as been a push for everything to specify tags vs latest, plus it ensures FedRAMP team can submit PR's just for updated the image without making empty commits
* Validated that the new base image still works in a commercial cluster

The heavy forwarder still has some issues to address but its currently not leveraged by FedRAMP and i believe nowhere currently so its not critical. Only the regular splunkforwarder was tested using the splunkforwarder applied via MCC to all clusters.