### PR TITLE
moves splunk start to goroutine, adds log tailing of splunkd for pod logs

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -124,8 +124,7 @@ no_proxy = %s
 }
 
 var cmd *exec.Cmd
-var tail *exec.Cmd
-var ctx, stop = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+var ctx, _ = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 func RunSplunk() bool {
 	args := []string{"start", "--answer-yes", "--nodaemon"}
@@ -133,18 +132,18 @@ func RunSplunk() bool {
 	cmd = exec.CommandContext(ctx, os.ExpandEnv(SplunkPath), args...)
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
-	cmd.Start()
-	cmd.Wait()
+	_ = cmd.Start()
+	_ = cmd.Wait()
 	return ctx.Err() == nil
 }
 
 func TailFile() bool {
 	args := []string{"-F", os.ExpandEnv(SplunkdLogPath)}
-	tail = exec.CommandContext(ctx, "/usr/bin/tail", args...)
+	tail := exec.CommandContext(ctx, "/usr/bin/tail", args...)
 	tail.Stdout = os.Stderr
 	tail.Stderr = os.Stderr
-	tail.Start()
-	tail.Wait()
+	_ = tail.Start()
+	_ = tail.Wait()
 	return ctx.Err() == nil
 }
 


### PR DESCRIPTION
For [OSD-21059](https://issues.redhat.com//browse/OSD-21059)

Changes:
* Moves the splunk startup process to a goroutine
* Adds a new tail function for tailing the splunkd log
* Changes the focus of the main process to log tailing

Reasoning:
The main goal is to make the splunkd logs visible when running `oc logs POD_NAME` to improve troubleshooting. Currently they are only viewable by rsh/exec'ing into the pod and viewing the log file.

* After trying a few different configurations, I could not find a way to capture both the splunk start process output and then tail the splunkd logs after without moving the splunk process to its own thread (seems like separating the processes make sense here anyway? Similar to how the health server is just running in another thread.)
* By pushing splunk to its own goroutine, the process is properly started in the background, and the main pod process begins to tail the splunkd using the same for loop logic that splunk is using.
* Using this structure, the splunk startup process still dumps to pod logs, but once its started, it then begins to start dumping the logs in splunkd which is ultimately the desire here.

There are probably better ways to implement this, but without rewriting everything, and sticking to a pattern that seems t be working fine, this is what i've got. Open to suggestions if there is a better way to handle this!

I've been testing this in a dev cluster in FedRAMP and so far everything is looking great. Not sure if there is any testing done on these images of if we just let this sit in non-prod for a bit and validate no log loss.


Testing:
I've had this running in a test cluster for a few days and pod logs capture both outputs as desired, and is forwarding to splunk with no issues.