### PR TITLE
use team alias in OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,8 @@
 reviewers:
-- wshearn
-- jaybeeunix
-- gsleeman
-- c-e-brumm
+- afreiberger
+- srep-functional-team-security
 approvers:
-- wshearn
-- jaybeeunix
-- gsleeman
+- srep-functional-team-security
 - karthikperu7
 maintainers:
 - jaybeeunix


### PR DESCRIPTION
Updates the OWNERS file to use the team alias so we don't have to add or remove people on a case-by-case basis. Also removes @c-e-brumm from approvers and adds @afreiberger.