### PR TITLE
[OSD-25400] Fix metrics endpoint

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -96,7 +96,7 @@ func genPasswd() ([]byte, error) {
 }
 
 func generateUserSeed() error {
-	if seedFile, err := os.OpenFile(os.ExpandEnv(userSeedPath), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644); err != nil {
+	if seedFile, err := os.OpenFile(os.ExpandEnv(userSeedPath), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644); err != nil {
 		return err
 	} else if passwd, err := genPasswd(); err != nil {
 		return err
@@ -108,7 +108,7 @@ func generateUserSeed() error {
 }
 
 func enableSplunkAPI() error {
-	if serverFile, err := os.OpenFile(os.ExpandEnv(serverConfigPath), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644); err != nil {
+	if serverFile, err := os.OpenFile(os.ExpandEnv(serverConfigPath), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644); err != nil {
 		return err
 	} else {
 		defer serverFile.Close()

--- a/runner.go
+++ b/runner.go
@@ -116,11 +116,7 @@ func enableSplunkAPI() error {
 enableSplunkdSSL = false
 [httpServer]
 acceptFrom = 127.0.0.1/8
-[proxyConfig]
-http_proxy = %s
-https_proxy = %s
-no_proxy = %s
-`, os.Getenv("HTTP_PROXY"), os.Getenv("HTTPS_PROXY"), os.Getenv("no_proxy"))
+`)
 
 		return err
 	}

--- a/runner.go
+++ b/runner.go
@@ -209,7 +209,7 @@ func StartServer() {
 		}
 	}))
 
-	http.ListenAndServe("0.0.0.0:8090", http.DefaultServeMux)
+	http.ListenAndServe("0.0.0.0:8090", nil)
 }
 
 func (h *SplunkHealth) Check() bool {

--- a/runner.go
+++ b/runner.go
@@ -45,18 +45,13 @@ type Status struct {
 	} `json:"reasons,omitempty"`
 }
 
+func (s Status) Healthy() bool {
+	return s.Health == "green"
+}
+
 type Feature struct {
 	Status
 	Features map[string]Feature `json:"features,omitempty"`
-}
-
-type SplunkHealth Feature
-
-var healthURL = &url.URL{
-	Scheme:   "http",
-	Host:     splunkHost,
-	Path:     healthEndpoint,
-	RawQuery: url.Values{"output_mode": []string{"json"}}.Encode(),
 }
 
 func (s Feature) Flatten(prefix ...string) map[string]Status {
@@ -72,12 +67,17 @@ func (s Feature) Flatten(prefix ...string) map[string]Status {
 	return out
 }
 
-func (s Status) Healthy() bool {
-	return s.Health == "green"
-}
+type SplunkHealth Feature
 
 func (s SplunkHealth) Flatten() map[string]Status {
 	return (Feature)(s).Flatten()
+}
+
+var healthURL = &url.URL{
+	Scheme:   "http",
+	Host:     splunkHost,
+	Path:     healthEndpoint,
+	RawQuery: url.Values{"output_mode": []string{"json"}}.Encode(),
 }
 
 func genPasswd() ([]byte, error) {

--- a/runner.go
+++ b/runner.go
@@ -21,6 +21,8 @@ import (
 
 const (
 	healthEndpoint          = "/services/server/health/splunkd/details"
+	notOk                   = "not ok\n"
+	ok                      = "ok\n"
 	serverConfigPath        = "${SPLUNK_HOME}/etc/system/local/server.conf"
 	splunkCACert            = "${SPLUNK_HOME}/etc/auth/cacert.pem"
 	splunkFlagAcceptLicense = "--accept-license"
@@ -182,20 +184,20 @@ func StartServer() {
 	http.Handle("/livez", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
 			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("not ok"))
+			w.Write([]byte(notOk))
 		} else {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("ok"))
+			w.Write([]byte(ok))
 		}
 	}))
 
 	http.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if health.Check() {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("ok"))
+			w.Write([]byte(ok))
 		} else {
 			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("not ok"))
+			w.Write([]byte(notOk))
 		}
 		nok := map[bool]string{false: "not ok", true: "ok"}
 		if r.URL.Query().Has("verbose") {


### PR DESCRIPTION
Enables TCP mode for the splunkd admin endpoint, which will allow the Go process to access it again.

This PR also includes some code cleanup that I've had sitting around.