### PR TITLE
use correct version tag for images

### DIFF
--- a/variables.mk
+++ b/variables.mk
@@ -7,14 +7,14 @@ CONTAINER_ENGINE_CONFIG_DIR = .docker
 # Accommodate docker or podman
 CONTAINER_ENGINE=$(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 
-SPLUNK_VERSION=$(shell cat .splunk-version)
-SPLUNK_HASH=$(shell cat .splunk-version-hash)
-CURRENT_COMMIT=$(shell git rev-parse --short=7 HEAD)
-IMAGE_TAG=$(SPLUNK_VERSION)-$(SPLUNK_HASH)-$(CURRENT_COMMIT)
+SPLUNK_VERSION = $(shell cat .splunk-version)
+SPLUNK_HASH = $(shell cat .splunk-version-hash)
+CURRENT_COMMIT = $(shell git rev-parse --short=7 HEAD)
+IMAGE_TAG = $(SPLUNK_VERSION)-$(SPLUNK_HASH)-$(CURRENT_COMMIT)
 
 IMAGE_REGISTRY ?= quay.io
 IMAGE_REPOSITORY ?= app-sre
-
-IMAGE_NAME=splunk-forwarder
-IMAGE_URI=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):$(IMAGE_TAG)
+IMAGE_NAME = splunk-forwarder
+IMAGE = $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME)
+IMAGE_URI := $(IMAGE):$(IMAGE_TAG)
 DOCKERFILE = ./containers/forwarder/Dockerfile


### PR DESCRIPTION
Boilerplate does not allow conditionally assigning the `IMAGE_TAG` variable, but it *does* allow it for `IMAGE_URI`. Since `IMAGE_TAG` is also being defined in boilerplate/openshift/osd-container-image/standard.mk:47, the Boilerplate assignment is in use when `IMAGE_URI` is finally evaluated and expanded when it's used as part of the build step. Adding the colon to the assignment in variables.mk:19 tells `make` to evaluate it immediately when the tag is in the correct format, instead of lazily evaluating when the build occurs. The immediate evaluation is then passed on to the conditional assignment.