### PR TITLE
Remove srep-infra-cicd from OWNERS files [SDCICD-1761]

### DIFF
--- a/.tekton/OWNERS
+++ b/.tekton/OWNERS
@@ -1,0 +1,9 @@
+reviewers:
+- srep-functional-team-security
+- srep-functional-team-rocket
+approvers:
+- srep-functional-team-security
+- srep-functional-team-rocket
+- srep-functional-team-fedramp
+- srep-functional-leads
+- srep-team-leads


### PR DESCRIPTION
The srep-infra-cicd migration is now complete. This PR removes the team as owners from this repository.

Related: Similar cleanup across OpenShift managed services repositories.